### PR TITLE
fix login/logout

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :authenticate_user!
   def index
     render html: "", layout: true
   end

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,0 +1,2 @@
+<footer>
+</footer>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,0 +1,3 @@
+<header>
+  <%= link_to 'logout', :controller => 'devise/sessions', :action => "destroy"  %>
+</header>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,8 @@
   </head>
 
   <body>
+    <%= render 'layouts/header' %>
     <%= yield %>
+    <%= render 'layouts/footer' %>
   </body>
 </html>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -258,7 +258,7 @@ Devise.setup do |config|
   # config.navigational_formats = ['*/*', :html]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :delete
+  config.sign_out_via = :get
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting

--- a/doc/scraping.md
+++ b/doc/scraping.md
@@ -25,8 +25,7 @@ https://pokemongo.gamewith.jp/article/show/26775
 - script を作成する  
   実装については `lib/task/scrape.rake` を参照してください．
   - 取得先サイトについては chrome 開発者ツールをもとに，適切な XPath を設定した．
-  - 正規表現は以下を参考にした．  
-    https://qiita.com/necojackarc/items/cad2d4eb80f0629ad196
+  - マスタ系の DB への値注入までを行う
 
 ## Execute script
 


### PR DESCRIPTION
開発環境(たとえば http://localhost:3000/)にアクセスしたときに，ログインしていなければ，/users/sign_in に飛ばすようにしました．
このとき，sign_in 画面上では，
* ユーザログイン
* ユーザアカウント登録
* Twitter account 連携
* パスワードを忘れた場合
のそれぞれの選択肢が出るようになっています．
また，login 時には / 配下に遷移します．

devise を使うようにしたので，sign_in 時の各画面要素(html.erb) は app/views/users/ 配下のディレクトリに格納されています．